### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   
   pushd kernel-687
   
-  make defconfig
+  make ARCH=arm64 defconfig
   
   scripts/config --file .config --enable ARM64_PMEM
   


### PR DESCRIPTION
Added ARCH=arm64 in make defconfig, in order to use the arm64/defconfig when cross-compiling.